### PR TITLE
Neatening Menus class

### DIFF
--- a/source/Menus.cs
+++ b/source/Menus.cs
@@ -129,7 +129,6 @@ namespace DreadBot
                         }
                         return;
                     }
-                case CallbackBotAdmins: { return; }
                 case CallbackDebugChat: {
                         Methods.answerCallbackQuery(callback.id);
                         string text = 
@@ -415,6 +414,20 @@ namespace DreadBot
                         }
                         return;
                     }
+                
+                // Not yet implemented
+                case CallbackDatabaseManagement:
+                case CallbackPluginManagement:
+                case CallbackBotAdmins:
+                case CallbackWebhookDisable:
+                default:
+                    {
+                        Methods.answerCallbackQuery(callback.id);
+                        const string text = "This menu option has not yet been implemented.";
+                        Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", BackOnly(CallbackBotManagement));
+                        return;
+                    }
+                    
             }
         }
 

--- a/source/Menus.cs
+++ b/source/Menus.cs
@@ -52,7 +52,19 @@ namespace DreadBot
         private const string CallbackGetUpdatesMinusSmall = "gulm1";
         private const string CallbackGetUpdatesMinusLarge = "gulm10";
 
+        private const string AdminMenuText =
+            "*DreadBot Administration Menu*\n\n" +
+            "`DreadBot Management`\nUsed to fine tune the bot, plus other senstive, and powerful options.\n\n" +
+            "`DataBase Management`\nConfigure Specific Database options, and backup as needed.\n\n" +
+            "`Plugin Manager`\nAdd, Remove and Configure plugins to give DreadBot its purpose.";
+
         #region Button Event Logic
+
+        internal static void PostAdminMenu(long chatId)
+        {
+            Result<Message> res = Methods.sendMessage(chatId, AdminMenuText, "Markdown", Menus.AdminMenu());
+            if (!res.ok) { Logger.LogError("Error contacting the admin Chat: " + res.description); }
+        }
 
         internal static void ButtonPush(CallbackQuery callback)
         {
@@ -60,7 +72,13 @@ namespace DreadBot
 
             switch (arg)
             {
-                case CallbackBotManagement: {
+                case CallbackRoot:
+                {
+                    Methods.editMessageText(callback.from.id, callback.message.message_id, AdminMenuText, "Markdown", AdminMenu());
+                    return;
+                }
+                case CallbackBotManagement: 
+                {
                         Methods.answerCallbackQuery(callback.id);
                         string text = 
                             "*DreadBot Management Options*\n\n" +
@@ -420,7 +438,6 @@ namespace DreadBot
                     }
                 
                 // Not yet implemented
-                case CallbackRoot:
                 case CallbackDatabaseManagement:
                 case CallbackPluginManagement:
                 case CallbackBotAdmins:

--- a/source/Menus.cs
+++ b/source/Menus.cs
@@ -27,30 +27,33 @@ namespace DreadBot
 {
     class Menus
     {
-        private const string CallbackRoot = "adm";
-        private const string CallbackBotManagement = "botadm";
-        private const string CallbackDatabaseManagement = "dbadm";
-        private const string CallbackPluginManagement = "plugadm";
-        private const string CallbackSensitiveOptions = "tunables";
-        private const string CallbackBotAdmins = "botadmins";
-        private const string CallbackDebugChat = "debugchatcfg";
-        private const string CallbackSounds = "sounds";
-        private const string CallbackLogLevel = "debugchatlevel";
-        private const string CallbackLogLevelSetChat = "cll";
-        private const string CallbackLogLevelSetFile = "fll";
-        private const string CallbackResetDebugChat = "resetdebug";
-        private const string CallbackChangeDebugChat = "changedebugchat";
-        private const string CallbackOperationMode = "operationmode";
-        private const string CallbackWebhookDisable = "disablewebhook";
-        private const string CallbackWebhookConfig = "webhookcfg";
-        private const string CallbackShowToken = "showtoken";
-        private const string CallbackChangeToken = "changetoken";
-        private const string CallbackChangeOwner = "changeowner";
-        private const string CallbackGetUpdatesLimit = "gulhelp";
-        private const string CallbackGetUpdatesPlusSmall = "gula1";
-        private const string CallbackGetUpdatesPlusLarge = "gula10";
-        private const string CallbackGetUpdatesMinusSmall = "gulm1";
-        private const string CallbackGetUpdatesMinusLarge = "gulm10";
+        class Callback
+        {
+            internal const string Root = "adm";
+            internal const string BotManagement = "botadm";
+            internal const string DatabaseManagement = "dbadm";
+            internal const string PluginManagement = "plugadm";
+            internal const string SensitiveOptions = "tunables";
+            internal const string BotAdmins = "botadmins";
+            internal const string DebugChat = "debugchatcfg";
+            internal const string Sounds = "sounds";
+            internal const string LogLevel = "debugchatlevel";
+            internal const string LogLevelSetChat = "cll";
+            internal const string LogLevelSetFile = "fll";
+            internal const string ResetDebugChat = "resetdebug";
+            internal const string ChangeDebugChat = "changedebugchat";
+            internal const string OperationMode = "operationmode";
+            internal const string WebhookDisable = "disablewebhook";
+            internal const string WebhookConfig = "webhookcfg";
+            internal const string ShowToken = "showtoken";
+            internal const string ChangeToken = "changetoken";
+            internal const string ChangeOwner = "changeowner";
+            internal const string GetUpdatesLimit = "gulhelp";
+            internal const string GetUpdatesPlusSmall = "gula1";
+            internal const string GetUpdatesPlusLarge = "gula10";
+            internal const string GetUpdatesMinusSmall = "gulm1";
+            internal const string GetUpdatesMinusLarge = "gulm10";
+        }
 
         private const string AdminMenuText =
             "*DreadBot Administration Menu*\n\n" +
@@ -72,12 +75,12 @@ namespace DreadBot
 
             switch (arg)
             {
-                case CallbackRoot:
+                case Callback.Root:
                 {
                     Methods.editMessageText(callback.from.id, callback.message.message_id, AdminMenuText, "Markdown", AdminMenu());
                     return;
                 }
-                case CallbackBotManagement: 
+                case Callback.BotManagement: 
                 {
                         Methods.answerCallbackQuery(callback.id);
                         string text = 
@@ -106,7 +109,7 @@ namespace DreadBot
                         Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", ManagementMenu());
                         return;
                     }
-                case CallbackSensitiveOptions: {
+                case Callback.SensitiveOptions: {
 
                         if (callback.from.id != Configs.RunningConfig.Owner)
                         {
@@ -151,7 +154,7 @@ namespace DreadBot
                         }
                         return;
                     }
-                case CallbackDebugChat: {
+                case Callback.DebugChat: {
                         Methods.answerCallbackQuery(callback.id);
                         string text = 
                             "*Debug Chat Settings*\n\n" +
@@ -169,7 +172,7 @@ namespace DreadBot
                         Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", DebugChatCfg());
                         return;
                     }
-                case CallbackLogLevel:
+                case Callback.LogLevel:
                     {
                         Methods.answerCallbackQuery(callback.id);
                         string text = 
@@ -182,7 +185,7 @@ namespace DreadBot
                         Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", LogLevelMenu());
                         return;
                     }
-                case CallbackResetDebugChat:
+                case Callback.ResetDebugChat:
                     {
                         string text = "Debug chat is already set to PM.";
                         if (Configs.RunningConfig.Owner != Configs.RunningConfig.AdminChat)
@@ -193,7 +196,7 @@ namespace DreadBot
                         Methods.answerCallbackQuery(callback.id, text, true);
                         return;
                     }
-                case CallbackChangeDebugChat:
+                case Callback.ChangeDebugChat:
                     {
                         Methods.answerCallbackQuery(callback.id);
                         string text = 
@@ -207,7 +210,7 @@ namespace DreadBot
                         Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", ChangeDebugChat());
                         return;
                     }
-                case CallbackOperationMode:
+                case Callback.OperationMode:
                     {
                         Methods.answerCallbackQuery(callback.id);
                         string text = 
@@ -223,7 +226,7 @@ namespace DreadBot
                         Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", OperationMenu());
                         return;
                     }
-                case CallbackWebhookConfig:
+                case Callback.WebhookConfig:
                     {
                         Methods.answerCallbackQuery(callback.id);
                         string text = 
@@ -245,12 +248,12 @@ namespace DreadBot
                         return;
                     }
 
-                case CallbackShowToken:
+                case Callback.ShowToken:
                     {
                         if (callback.from.id == Configs.RunningConfig.Owner)
                         {
                             Methods.answerCallbackQuery(callback.id);
-                            Methods.editMessageText(callback.from.id, callback.message.message_id, "`" + Configs.RunningConfig.token + "`", "markdown", BackOnly(CallbackSensitiveOptions));
+                            Methods.editMessageText(callback.from.id, callback.message.message_id, "`" + Configs.RunningConfig.token + "`", "markdown", BackOnly(Callback.SensitiveOptions));
                             return;
                         }
                         else {
@@ -260,7 +263,7 @@ namespace DreadBot
                         }
                         return;
                     }
-                case CallbackChangeToken:
+                case Callback.ChangeToken:
                     {
                         if (callback.from.id == Configs.RunningConfig.Owner)
                         {
@@ -271,7 +274,7 @@ namespace DreadBot
                                 "This is a major change to make. Please read " +
                                 "[this](http://dreadbot.net/wiki/index.php/Change_Token) page before proceeding.", 
                                 "markdown", 
-                                BackOnly(CallbackSensitiveOptions));
+                                BackOnly(Callback.SensitiveOptions));
                             return;
                         }
                         else
@@ -282,7 +285,7 @@ namespace DreadBot
                         }
                         return;
                     }
-                case CallbackChangeOwner:
+                case Callback.ChangeOwner:
                     {
                         if (callback.from.id == Configs.RunningConfig.Owner)
                         {
@@ -295,7 +298,7 @@ namespace DreadBot
                                 "been made.\nPlease read [this](http://dreadbot.net/wiki/index.php/Change_Owner) " +
                                 "page before proceeding.", 
                                 "markdown", 
-                                BackOnly(CallbackSensitiveOptions));
+                                BackOnly(Callback.SensitiveOptions));
                             return;
                         }
                         else
@@ -306,12 +309,12 @@ namespace DreadBot
                         }
                         return;
                     }
-                case CallbackGetUpdatesLimit:
+                case Callback.GetUpdatesLimit:
                     {
                         Methods.answerCallbackQuery(callback.id, "Changes the Get Updates limit", true);
                         return;
                     }
-                case CallbackGetUpdatesPlusSmall: {
+                case Callback.GetUpdatesPlusSmall: {
                         if (callback.from.id == Configs.RunningConfig.Owner)
                         {
                             if (Configs.RunningConfig.GULimit > 100)
@@ -339,7 +342,7 @@ namespace DreadBot
                         }
                         return;
                     }
-                case CallbackGetUpdatesPlusLarge:
+                case Callback.GetUpdatesPlusLarge:
                     {
                         if (callback.from.id == Configs.RunningConfig.Owner)
                         {
@@ -373,7 +376,7 @@ namespace DreadBot
                         }
                         return;
                     }
-                case CallbackGetUpdatesMinusLarge:
+                case Callback.GetUpdatesMinusLarge:
                     {
                         if (callback.from.id == Configs.RunningConfig.Owner)
                         {
@@ -407,7 +410,7 @@ namespace DreadBot
                         }
                         return;
                     }
-                case CallbackGetUpdatesMinusSmall:
+                case Callback.GetUpdatesMinusSmall:
                     {
                         if (callback.from.id == Configs.RunningConfig.Owner)
                         {
@@ -438,18 +441,18 @@ namespace DreadBot
                     }
                 
                 // Not yet implemented
-                case CallbackDatabaseManagement:
-                case CallbackPluginManagement:
-                case CallbackBotAdmins:
-                case CallbackSounds: 
-                case CallbackLogLevelSetChat: 
-                case CallbackLogLevelSetFile:
-                case CallbackWebhookDisable:
+                case Callback.DatabaseManagement:
+                case Callback.PluginManagement:
+                case Callback.BotAdmins:
+                case Callback.Sounds: 
+                case Callback.LogLevelSetChat: 
+                case Callback.LogLevelSetFile:
+                case Callback.WebhookDisable:
                 default:
                     {
                         Methods.answerCallbackQuery(callback.id);
                         const string text = "This menu option has not yet been implemented.";
-                        Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", BackOnly(CallbackRoot));
+                        Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", BackOnly(Callback.Root));
                         return;
                     }
                     
@@ -466,9 +469,9 @@ namespace DreadBot
         {
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
-            keyboard.addCallbackButton("🎛 DreadBot Management", $"dreadbot {CallbackBotManagement}", 0);
-            keyboard.addCallbackButton("🗄 DataBase Management", $"dreadbot {CallbackDatabaseManagement}", 1);
-            keyboard.addCallbackButton("⚡️ Plugin Manager", $"dreadbot {CallbackPluginManagement}", 2);
+            keyboard.addCallbackButton("🎛 DreadBot Management", $"dreadbot {Callback.BotManagement}", 0);
+            keyboard.addCallbackButton("🗄 DataBase Management", $"dreadbot {Callback.DatabaseManagement}", 1);
+            keyboard.addCallbackButton("⚡️ Plugin Manager", $"dreadbot {Callback.PluginManagement}", 2);
             return keyboard;
         }
 
@@ -476,11 +479,11 @@ namespace DreadBot
         {
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
-            keyboard.addCallbackButton("🔥 Sensitive Options", $"dreadbot {CallbackSensitiveOptions}", 0);
-            keyboard.addCallbackButton("👮‍♂️ Add/Remove Bot Admins", $"dreadbot {CallbackBotAdmins}", 1);
-            keyboard.addCallbackButton("🗒 Debug Chat Settings", $"dreadbot {CallbackDebugChat}", 2);
-            keyboard.addCallbackButton("🔉 System Sounds", $"dreadbot {CallbackSounds}", 3);
-            keyboard.addCallbackButton("🔙", $"dreadbot {CallbackRoot}", 4);
+            keyboard.addCallbackButton("🔥 Sensitive Options", $"dreadbot {Callback.SensitiveOptions}", 0);
+            keyboard.addCallbackButton("👮‍♂️ Add/Remove Bot Admins", $"dreadbot {Callback.BotAdmins}", 1);
+            keyboard.addCallbackButton("🗒 Debug Chat Settings", $"dreadbot {Callback.DebugChat}", 2);
+            keyboard.addCallbackButton("🔉 System Sounds", $"dreadbot {Callback.Sounds}", 3);
+            keyboard.addCallbackButton("🔙", $"dreadbot {Callback.Root}", 4);
             return keyboard;
         }
 
@@ -488,8 +491,8 @@ namespace DreadBot
         {
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
-            keyboard.addCallbackButton("Reset Debug Chat to Private", $"dreadbot {CallbackResetDebugChat}", 0);
-            keyboard.addCallbackButton("🔙", $"dreadbot {CallbackDebugChat}", 1);
+            keyboard.addCallbackButton("Reset Debug Chat to Private", $"dreadbot {Callback.ResetDebugChat}", 0);
+            keyboard.addCallbackButton("🔙", $"dreadbot {Callback.DebugChat}", 1);
             return keyboard;
         }
 
@@ -497,28 +500,28 @@ namespace DreadBot
         {
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
-            keyboard.addCallbackButton("File LogLevel - Debug " + GetLogLevel(LogLevel.Debug, false), $"dreadbot {CallbackLogLevelSetFile} 6", 0);
-            keyboard.addCallbackButton("Console LogLevel - Debug " + GetLogLevel(LogLevel.Debug), $"dreadbot {CallbackLogLevelSetChat} 6", 0);
+            keyboard.addCallbackButton("File LogLevel - Debug " + GetLogLevel(LogLevel.Debug, false), $"dreadbot {Callback.LogLevelSetFile} 6", 0);
+            keyboard.addCallbackButton("Console LogLevel - Debug " + GetLogLevel(LogLevel.Debug), $"dreadbot {Callback.LogLevelSetChat} 6", 0);
 
-            keyboard.addCallbackButton("File LogLevel - Admin " + GetLogLevel(LogLevel.Admin, false), $"dreadbot {CallbackLogLevelSetFile} 5", 1);
-            keyboard.addCallbackButton("Console LogLevel - Admin " + GetLogLevel(LogLevel.Admin), $"dreadbot {CallbackLogLevelSetChat} 5", 1);
+            keyboard.addCallbackButton("File LogLevel - Admin " + GetLogLevel(LogLevel.Admin, false), $"dreadbot {Callback.LogLevelSetFile} 5", 1);
+            keyboard.addCallbackButton("Console LogLevel - Admin " + GetLogLevel(LogLevel.Admin), $"dreadbot {Callback.LogLevelSetChat} 5", 1);
 
-            keyboard.addCallbackButton("File LogLevel - Info " + GetLogLevel(LogLevel.Info, false), $"dreadbot {CallbackLogLevelSetFile} 4", 2);
-            keyboard.addCallbackButton("Console LogLevel - Info " + GetLogLevel(LogLevel.Info), $"dreadbot {CallbackLogLevelSetChat} 4", 2);
+            keyboard.addCallbackButton("File LogLevel - Info " + GetLogLevel(LogLevel.Info, false), $"dreadbot {Callback.LogLevelSetFile} 4", 2);
+            keyboard.addCallbackButton("Console LogLevel - Info " + GetLogLevel(LogLevel.Info), $"dreadbot {Callback.LogLevelSetChat} 4", 2);
 
-            keyboard.addCallbackButton("File LogLevel - Warn " + GetLogLevel(LogLevel.Warn, false), $"dreadbot {CallbackLogLevelSetFile} 3", 3);
-            keyboard.addCallbackButton("Console LogLevel - Warn " + GetLogLevel(LogLevel.Warn), $"dreadbot {CallbackLogLevelSetChat} 3", 3);
+            keyboard.addCallbackButton("File LogLevel - Warn " + GetLogLevel(LogLevel.Warn, false), $"dreadbot {Callback.LogLevelSetFile} 3", 3);
+            keyboard.addCallbackButton("Console LogLevel - Warn " + GetLogLevel(LogLevel.Warn), $"dreadbot {Callback.LogLevelSetChat} 3", 3);
 
-            keyboard.addCallbackButton("File LogLevel - Error " + GetLogLevel(LogLevel.Error, false), $"dreadbot {CallbackLogLevelSetFile} 2", 4);
-            keyboard.addCallbackButton("Console LogLevel - Error " + GetLogLevel(LogLevel.Error), $"dreadbot {CallbackLogLevelSetChat} 2", 4);
+            keyboard.addCallbackButton("File LogLevel - Error " + GetLogLevel(LogLevel.Error, false), $"dreadbot {Callback.LogLevelSetFile} 2", 4);
+            keyboard.addCallbackButton("Console LogLevel - Error " + GetLogLevel(LogLevel.Error), $"dreadbot {Callback.LogLevelSetChat} 2", 4);
 
-            keyboard.addCallbackButton("File LogLevel - Fatal " + GetLogLevel(LogLevel.Fatal, false), $"dreadbot {CallbackLogLevelSetFile} 1", 5);
-            keyboard.addCallbackButton("Console LogLevel - Fatal " + GetLogLevel(LogLevel.Fatal), $"dreadbot {CallbackLogLevelSetChat} 1", 5);
+            keyboard.addCallbackButton("File LogLevel - Fatal " + GetLogLevel(LogLevel.Fatal, false), $"dreadbot {Callback.LogLevelSetFile} 1", 5);
+            keyboard.addCallbackButton("Console LogLevel - Fatal " + GetLogLevel(LogLevel.Fatal), $"dreadbot {Callback.LogLevelSetChat} 1", 5);
 
-            keyboard.addCallbackButton("File LogLevel - Off " + GetLogLevel(LogLevel.Off, false), $"dreadbot {CallbackLogLevelSetFile} 0", 6);
-            keyboard.addCallbackButton("Console LogLevel - Off " + GetLogLevel(LogLevel.Off), $"dreadbot {CallbackLogLevelSetChat} 0", 6);
+            keyboard.addCallbackButton("File LogLevel - Off " + GetLogLevel(LogLevel.Off, false), $"dreadbot {Callback.LogLevelSetFile} 0", 6);
+            keyboard.addCallbackButton("Console LogLevel - Off " + GetLogLevel(LogLevel.Off), $"dreadbot {Callback.LogLevelSetChat} 0", 6);
 
-            keyboard.addCallbackButton("🔙", $"dreadbot {CallbackDebugChat}", 7);
+            keyboard.addCallbackButton("🔙", $"dreadbot {Callback.DebugChat}", 7);
 
             return keyboard;
         }
@@ -527,9 +530,9 @@ namespace DreadBot
         {
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
-            keyboard.addCallbackButton("🧾 Change Debug Chat", $"dreadbot {CallbackChangeDebugChat}", 0);
-            keyboard.addCallbackButton("🔕 Set Debug Chat Log Level", $"dreadbot {CallbackLogLevel}", 1);
-            keyboard.addCallbackButton("🔙", $"dreadbot {CallbackBotManagement}", 2);
+            keyboard.addCallbackButton("🧾 Change Debug Chat", $"dreadbot {Callback.ChangeDebugChat}", 0);
+            keyboard.addCallbackButton("🔕 Set Debug Chat Log Level", $"dreadbot {Callback.LogLevel}", 1);
+            keyboard.addCallbackButton("🔙", $"dreadbot {Callback.BotManagement}", 2);
             return keyboard;
         }
         internal static InlineKeyboardMarkup PluginMgr()
@@ -547,9 +550,9 @@ namespace DreadBot
             string getUpdatesSuffix = Configs.RunningConfig.GetupdatesMode ? " ⬅️" : "";
             string webHooksSuffix = Configs.RunningConfig.GetupdatesMode ? "" : " ⬅️";
 
-            keyboard.addCallbackButton("GetUpdates" + getUpdatesSuffix, $"dreadbot {CallbackWebhookDisable}", 0);
-            keyboard.addCallbackButton("WebHook" + webHooksSuffix, $"dreadbot {CallbackWebhookConfig}", 1);
-            keyboard.addCallbackButton("🔙", $"dreadbot {CallbackSensitiveOptions}", 2);
+            keyboard.addCallbackButton("GetUpdates" + getUpdatesSuffix, $"dreadbot {Callback.WebhookDisable}", 0);
+            keyboard.addCallbackButton("WebHook" + webHooksSuffix, $"dreadbot {Callback.WebhookConfig}", 1);
+            keyboard.addCallbackButton("🔙", $"dreadbot {Callback.SensitiveOptions}", 2);
             return keyboard;
         }
 
@@ -558,15 +561,15 @@ namespace DreadBot
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
 
-            keyboard.addCallbackButton("Test & Go Live!", $"dreadbot {CallbackWebhookDisable}", 0);
-            keyboard.addCallbackButton("Set URL", $"dreadbot {CallbackWebhookConfig}", 1);
-            keyboard.addCallbackButton("Set Certificate", $"dreadbot {CallbackWebhookConfig}", 2);
+            keyboard.addCallbackButton("Test & Go Live!", $"dreadbot {Callback.WebhookDisable}", 0);
+            keyboard.addCallbackButton("Set URL", $"dreadbot {Callback.WebhookConfig}", 1);
+            keyboard.addCallbackButton("Set Certificate", $"dreadbot {Callback.WebhookConfig}", 2);
 
-            keyboard.addCallbackButton("Port Cfg", $"dreadbot {CallbackWebhookConfig}", 3);
-            keyboard.addCallbackButton("443", $"dreadbot {CallbackWebhookConfig}", 3);
-            keyboard.addCallbackButton("+", $"dreadbot {CallbackWebhookConfig}", 3);
+            keyboard.addCallbackButton("Port Cfg", $"dreadbot {Callback.WebhookConfig}", 3);
+            keyboard.addCallbackButton("443", $"dreadbot {Callback.WebhookConfig}", 3);
+            keyboard.addCallbackButton("+", $"dreadbot {Callback.WebhookConfig}", 3);
 
-            keyboard.addCallbackButton("🔙", $"dreadbot {CallbackOperationMode}", 4);
+            keyboard.addCallbackButton("🔙", $"dreadbot {Callback.OperationMode}", 4);
             return keyboard;
         }
         
@@ -574,18 +577,18 @@ namespace DreadBot
         {
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
-            keyboard.addCallbackButton("🔑 Show Access Token", $"dreadbot {CallbackShowToken}", 0);
-            keyboard.addCallbackButton("🔑 Change Access Token", $"dreadbot {CallbackChangeToken}", 1);
-            keyboard.addCallbackButton("👮‍️ Change Owner", $"dreadbot {CallbackChangeOwner}", 2);
+            keyboard.addCallbackButton("🔑 Show Access Token", $"dreadbot {Callback.ShowToken}", 0);
+            keyboard.addCallbackButton("🔑 Change Access Token", $"dreadbot {Callback.ChangeToken}", 1);
+            keyboard.addCallbackButton("👮‍️ Change Owner", $"dreadbot {Callback.ChangeOwner}", 2);
 
-            keyboard.addCallbackButton("+1", $"dreadbot {CallbackGetUpdatesPlusSmall}", 3);
-            keyboard.addCallbackButton("+10", $"dreadbot {CallbackGetUpdatesPlusLarge}", 3);
-            keyboard.addCallbackButton(Configs.RunningConfig.GULimit.ToString(), $"dreadbot {CallbackGetUpdatesLimit}", 3);
-            keyboard.addCallbackButton("-10", $"dreadbot {CallbackGetUpdatesMinusLarge}", 3);
-            keyboard.addCallbackButton("-1", $"dreadbot {CallbackGetUpdatesMinusSmall}", 3);
+            keyboard.addCallbackButton("+1", $"dreadbot {Callback.GetUpdatesPlusSmall}", 3);
+            keyboard.addCallbackButton("+10", $"dreadbot {Callback.GetUpdatesPlusLarge}", 3);
+            keyboard.addCallbackButton(Configs.RunningConfig.GULimit.ToString(), $"dreadbot {Callback.GetUpdatesLimit}", 3);
+            keyboard.addCallbackButton("-10", $"dreadbot {Callback.GetUpdatesMinusLarge}", 3);
+            keyboard.addCallbackButton("-1", $"dreadbot {Callback.GetUpdatesMinusSmall}", 3);
 
-            keyboard.addCallbackButton("⚙️ Bot Operation Mode", $"dreadbot {CallbackOperationMode}", 4);
-            keyboard.addCallbackButton("🔙", $"dreadbot {CallbackBotManagement}", 5);
+            keyboard.addCallbackButton("⚙️ Bot Operation Mode", $"dreadbot {Callback.OperationMode}", 4);
+            keyboard.addCallbackButton("🔙", $"dreadbot {Callback.BotManagement}", 5);
             return keyboard;
 
         }

--- a/source/Menus.cs
+++ b/source/Menus.cs
@@ -27,13 +27,17 @@ namespace DreadBot
 {
     class Menus
     {
+        private const string CallbackRoot = "adm";
         private const string CallbackBotManagement = "botadm";
         private const string CallbackDatabaseManagement = "dbadm";
         private const string CallbackPluginManagement = "plugadm";
         private const string CallbackSensitiveOptions = "tunables";
         private const string CallbackBotAdmins = "botadmins";
         private const string CallbackDebugChat = "debugchatcfg";
+        private const string CallbackSounds = "sounds";
         private const string CallbackLogLevel = "debugchatlevel";
+        private const string CallbackLogLevelSetChat = "cll";
+        private const string CallbackLogLevelSetFile = "fll";
         private const string CallbackResetDebugChat = "resetdebug";
         private const string CallbackChangeDebugChat = "changedebugchat";
         private const string CallbackOperationMode = "operationmode";
@@ -416,15 +420,19 @@ namespace DreadBot
                     }
                 
                 // Not yet implemented
+                case CallbackRoot:
                 case CallbackDatabaseManagement:
                 case CallbackPluginManagement:
                 case CallbackBotAdmins:
+                case CallbackSounds: 
+                case CallbackLogLevelSetChat: 
+                case CallbackLogLevelSetFile:
                 case CallbackWebhookDisable:
                 default:
                     {
                         Methods.answerCallbackQuery(callback.id);
                         const string text = "This menu option has not yet been implemented.";
-                        Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", BackOnly(CallbackBotManagement));
+                        Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", BackOnly(CallbackRoot));
                         return;
                     }
                     
@@ -454,8 +462,8 @@ namespace DreadBot
             keyboard.addCallbackButton("🔥 Sensitive Options", $"dreadbot {CallbackSensitiveOptions}", 0);
             keyboard.addCallbackButton("👮‍♂️ Add/Remove Bot Admins", $"dreadbot {CallbackBotAdmins}", 1);
             keyboard.addCallbackButton("🗒 Debug Chat Settings", $"dreadbot {CallbackDebugChat}", 2);
-            keyboard.addCallbackButton("🔉 System Sounds", "dreadbot sounds", 3);
-            keyboard.addCallbackButton("🔙", "dreadbot adm", 4);
+            keyboard.addCallbackButton("🔉 System Sounds", $"dreadbot {CallbackSounds}", 3);
+            keyboard.addCallbackButton("🔙", $"dreadbot {CallbackRoot}", 4);
             return keyboard;
         }
 
@@ -472,26 +480,26 @@ namespace DreadBot
         {
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
-            keyboard.addCallbackButton("File LogLevel - Debug " + GetLogLevel(LogLevel.Debug, false), "dreadbot fll 6", 0);
-            keyboard.addCallbackButton("Console LogLevel - Debug " + GetLogLevel(LogLevel.Debug), "dreadbot cll 6", 0);
+            keyboard.addCallbackButton("File LogLevel - Debug " + GetLogLevel(LogLevel.Debug, false), $"dreadbot {CallbackLogLevelSetFile} 6", 0);
+            keyboard.addCallbackButton("Console LogLevel - Debug " + GetLogLevel(LogLevel.Debug), $"dreadbot {CallbackLogLevelSetChat} 6", 0);
 
-            keyboard.addCallbackButton("File LogLevel - Admin " + GetLogLevel(LogLevel.Admin, false), "dreadbot fll 5", 1);
-            keyboard.addCallbackButton("Console LogLevel - Admin " + GetLogLevel(LogLevel.Admin), "dreadbot cll 5", 1);
+            keyboard.addCallbackButton("File LogLevel - Admin " + GetLogLevel(LogLevel.Admin, false), $"dreadbot {CallbackLogLevelSetFile} 5", 1);
+            keyboard.addCallbackButton("Console LogLevel - Admin " + GetLogLevel(LogLevel.Admin), $"dreadbot {CallbackLogLevelSetChat} 5", 1);
 
-            keyboard.addCallbackButton("File LogLevel - Info " + GetLogLevel(LogLevel.Info, false), "dreadbot fll 4", 2);
-            keyboard.addCallbackButton("Console LogLevel - Info " + GetLogLevel(LogLevel.Info), "dreadbot cll 4", 2);
+            keyboard.addCallbackButton("File LogLevel - Info " + GetLogLevel(LogLevel.Info, false), $"dreadbot {CallbackLogLevelSetFile} 4", 2);
+            keyboard.addCallbackButton("Console LogLevel - Info " + GetLogLevel(LogLevel.Info), $"dreadbot {CallbackLogLevelSetChat} 4", 2);
 
-            keyboard.addCallbackButton("File LogLevel - Warn " + GetLogLevel(LogLevel.Warn, false), "dreadbot fll 3", 3);
-            keyboard.addCallbackButton("Console LogLevel - Warn " + GetLogLevel(LogLevel.Warn), "dreadbot cll 3", 3);
+            keyboard.addCallbackButton("File LogLevel - Warn " + GetLogLevel(LogLevel.Warn, false), $"dreadbot {CallbackLogLevelSetFile} 3", 3);
+            keyboard.addCallbackButton("Console LogLevel - Warn " + GetLogLevel(LogLevel.Warn), $"dreadbot {CallbackLogLevelSetChat} 3", 3);
 
-            keyboard.addCallbackButton("File LogLevel - Error " + GetLogLevel(LogLevel.Error, false), "dreadbot fll 2", 4);
-            keyboard.addCallbackButton("Console LogLevel - Error " + GetLogLevel(LogLevel.Error), "dreadbot cll 2", 4);
+            keyboard.addCallbackButton("File LogLevel - Error " + GetLogLevel(LogLevel.Error, false), $"dreadbot {CallbackLogLevelSetFile} 2", 4);
+            keyboard.addCallbackButton("Console LogLevel - Error " + GetLogLevel(LogLevel.Error), $"dreadbot {CallbackLogLevelSetChat} 2", 4);
 
-            keyboard.addCallbackButton("File LogLevel - Fatal " + GetLogLevel(LogLevel.Fatal, false), "dreadbot fll 1", 5);
-            keyboard.addCallbackButton("Console LogLevel - Fatal " + GetLogLevel(LogLevel.Fatal), "dreadbot cll 1", 5);
+            keyboard.addCallbackButton("File LogLevel - Fatal " + GetLogLevel(LogLevel.Fatal, false), $"dreadbot {CallbackLogLevelSetFile} 1", 5);
+            keyboard.addCallbackButton("Console LogLevel - Fatal " + GetLogLevel(LogLevel.Fatal), $"dreadbot {CallbackLogLevelSetChat} 1", 5);
 
-            keyboard.addCallbackButton("File LogLevel - Off " + GetLogLevel(LogLevel.Off, false), "dreadbot fll 0", 6);
-            keyboard.addCallbackButton("Console LogLevel - Off " + GetLogLevel(LogLevel.Off), "dreadbot cll 0", 6);
+            keyboard.addCallbackButton("File LogLevel - Off " + GetLogLevel(LogLevel.Off, false), $"dreadbot {CallbackLogLevelSetFile} 0", 6);
+            keyboard.addCallbackButton("Console LogLevel - Off " + GetLogLevel(LogLevel.Off), $"dreadbot {CallbackLogLevelSetChat} 0", 6);
 
             keyboard.addCallbackButton("🔙", $"dreadbot {CallbackDebugChat}", 7);
 
@@ -569,7 +577,7 @@ namespace DreadBot
         {
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
-            keyboard.addCallbackButton("🔙", "dreadbot " + callBack, 0);
+            keyboard.addCallbackButton("🔙", $"dreadbot {callBack}", 0);
             return keyboard;
         }
 

--- a/source/Menus.cs
+++ b/source/Menus.cs
@@ -22,16 +22,31 @@
 //SOFTWARE.
 
 #endregion
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DreadBot
 {
     class Menus
     {
+        private const string CallbackBotManagement = "botadm";
+        private const string CallbackDatabaseManagement = "dbadm";
+        private const string CallbackPluginManagement = "plugadm";
+        private const string CallbackSensitiveOptions = "tunables";
+        private const string CallbackBotAdmins = "botadmins";
+        private const string CallbackDebugChat = "debugchatcfg";
+        private const string CallbackLogLevel = "debugchatlevel";
+        private const string CallbackResetDebugChat = "resetdebug";
+        private const string CallbackChangeDebugChat = "changedebugchat";
+        private const string CallbackOperationMode = "operationmode";
+        private const string CallbackWebhookDisable = "disablewebhook";
+        private const string CallbackWebhookConfig = "webhookcfg";
+        private const string CallbackShowToken = "showtoken";
+        private const string CallbackChangeToken = "changetoken";
+        private const string CallbackChangeOwner = "changeowner";
+        private const string CallbackGetUpdatesLimit = "gulhelp";
+        private const string CallbackGetUpdatesPlusSmall = "gula1";
+        private const string CallbackGetUpdatesPlusLarge = "gula10";
+        private const string CallbackGetUpdatesMinusSmall = "gulm1";
+        private const string CallbackGetUpdatesMinusLarge = "gulm10";
 
         #region Button Event Logic
 
@@ -41,13 +56,35 @@ namespace DreadBot
 
             switch (arg)
             {
-                case "botadm": {
+                case CallbackBotManagement: {
                         Methods.answerCallbackQuery(callback.id);
-                        string text = "*DreadBot Management Options*\n\nThese options are for the bot owner only (you) and are critical settings for the operation of your bot. Use these settings with care. All of these settings take immediate effect.\n\n`Sensitive Options`\nThese settings control very low level settings. Such as how often the bot will request new messages, setting up webhook, and more!\n\n`Add/Remove Bot Admins`\nIn the event you want to grant others control over the bot, manage who can use it, and what control they have over it, you can use this menu.\n\n`Debug Chat Settings`\nBy Default, the \"Debug Chat\" is PM between you and the bot. These settings let you use a group instead, as well as control what options can be set from this group. This can really help if you are tired of getting Debug messages in PM.\n\n`System Sounds`\nThis allows DreadBot to play custom sounds per events. You send DreadBot WAV/ MP3 Files to play to correlate to specific events.";
+                        string text = 
+                            "*DreadBot Management Options*\n\n" +
+                            
+                            "These options are for the bot owner only (you) and are critical settings for the " +
+                            "operation of your bot. Use these settings with care. All of these settings take " +
+                            "immediate effect.\n\n" +
+                            
+                            "`Sensitive Options`\n" +
+                            "These settings control very low level settings. Such as how often the bot will request " +
+                            "new messages, setting up webhook, and more!\n\n" +
+                            
+                            "`Add/Remove Bot Admins`\n" +
+                            "In the event you want to grant others control over the bot, manage who can use it, and " +
+                            "what control they have over it, you can use this menu.\n\n" +
+                            
+                            "`Debug Chat Settings`\n" +
+                            "By Default, the \"Debug Chat\" is PM between you and the bot. These settings let you " +
+                            "use a group instead, as well as control what options can be set from this group. This " +
+                            "can really help if you are tired of getting Debug messages in PM.\n\n" +
+                            
+                            "`System Sounds`\n" +
+                            "This allows DreadBot to play custom sounds per events. You send DreadBot WAV/ MP3 Files " +
+                            "to play to correlate to specific events.";
                         Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", ManagementMenu());
                         return;
                     }
-                case "tuneables": {
+                case CallbackSensitiveOptions: {
 
                         if (callback.from.id != Configs.RunningConfig.Owner)
                         {
@@ -58,72 +95,141 @@ namespace DreadBot
                         else
                         {
                             Methods.answerCallbackQuery(callback.id);
-                            string text = "*Sensitive Tunables*\n\nThese settings are VERY sensitive and alter how the bot will communicate with Telegram.\nDo not change these settings unless you are familiar with them!\n\n" +
-                                "`Show Access Token`\nThis will display the access token that the bot is using.\n\n" +
-                                "`Change Access Token`\nThis will allow you to change the access token and use a different bot account.\n*WARNING!* This can cause harmful side-effects to any database entries which plugins you have added are using.\nUSE WITH CAUTION!\n\n" +
-                                "`Change Owner`\nThis allows you to pass ownership of the bot to another Telegram user. Only the owner can use this button.\n\n" +
-                                "`Get Updates Limit`\nUsing the + - buttons, you can change the number of updates the bot will ask for when it gets messages from Telegram.\n(Min 1 - Max 100 - Default 20)\n\n" +
-                                "`Bot Operation Mode`\nThis allows you set change the bot's method of getting updates between getUpdates and WebHook. This can heavily impact the functionality of the bot and you shouldn't use it unless you know what you're doing.\n\n";
+                            string text = 
+                                "*Sensitive Options*\n\n" +
+                                
+                                "These settings are VERY sensitive and alter how the bot will communicate with " +
+                                "Telegram.\n" +
+                                "Do not change these settings unless you are familiar with them!\n\n" +
+                                
+                                "`Show Access Token`\n" +
+                                "This will display the access token that the bot is using.\n\n" +
+                                
+                                "`Change Access Token`\n" +
+                                "This will allow you to change the access token and use a different bot account.\n" +
+                                "*WARNING!* This can cause harmful side-effects to any database entries which " +
+                                "plugins you have added are using.\n" +
+                                "USE WITH CAUTION!\n\n" +
+                                
+                                "`Change Owner`\n" +
+                                "This allows you to pass ownership of the bot to another Telegram user. Only the " +
+                                "owner can use this button.\n\n" +
+                                
+                                "`Get Updates Limit`\n" +
+                                "Using the + - buttons, you can change the number of updates " +
+                                "the bot will ask for when it gets messages from Telegram.\n" +
+                                "(Min 1 - Max 100 - Default 20)\n\n" +
+                                
+                                "`Bot Operation Mode`\n" +
+                                "This allows you set change the bot's method of getting updates between getUpdates " +
+                                "and WebHook. This can heavily impact the functionality of the bot and you shouldn't " +
+                                "use it unless you know what you're doing.\n\n";
 
-                            Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", TuneablesMenu());
+                            Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", SensitiveOptionsMenu());
                         }
                         return;
                     }
-                case "botadmins": { return; }
-                case "debugchatcfg": {
+                case CallbackBotAdmins: { return; }
+                case CallbackDebugChat: {
                         Methods.answerCallbackQuery(callback.id);
-                        string text = "*Debug Chat Settings*\n\nHere you can configure the Debug Chat. This is used by the bot as a good testing grounds, somewhere to dump errors for all Bot Admins to see, admin commands and more.\n\n`Toggle Debug Chat Commands`\nEnable Bot Admin commands for use within the Debug Chat. Its very useful for troubleshooting, and testing.\n\n`Change Debug Chat`\nThis is what you use to change the Debug Chat to a Group, Supergroup, or back to Private (Bot Owner only).\n\n`Set the Debug Chat Log Level`\nHere you can set how verbose the bot is with its error reporting in the Debug Chat. We recommend at least [Warn] Level.";
+                        string text = 
+                            "*Debug Chat Settings*\n\n" +
+                            "Here you can configure the Debug Chat. This is used by the bot as a good testing " +
+                            "grounds, somewhere to dump errors for all Bot Admins to see, admin commands and more.\n\n" +
+                            "`Toggle Debug Chat Commands`\n" +
+                            "Enable Bot Admin commands for use within the Debug Chat. It's very useful for " +
+                            "troubleshooting, and testing.\n\n" +
+                            "`Change Debug Chat`\n" +
+                            "This is what you use to change " +
+                            "the Debug Chat to a Group, Supergroup, or back to Private (Bot Owner only).\n\n" +
+                            "`Set the Debug Chat Log Level`\n" +
+                            "Here you can set how verbose the bot is with its error reporting in the Debug Chat. " +
+                            "We recommend at least [Warn] level.";
                         Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", DebugChatCfg());
                         return;
                     }
-                case "debugchatlevel":
+                case CallbackLogLevel:
                     {
                         Methods.answerCallbackQuery(callback.id);
-                        string text = "*Log Level Configuration*\n\nHere you can set the desired log level of the Console and the Log File.\n\nThe right column is for the Console.\nThe left side is for the Log File. (it is log.txt and is off by default.)\n\nWe strongly recommend the console log level be no lower than *WARN* as some of this information can be important when resolving problems.";
+                        string text = 
+                            "*Log Level Configuration*\n\n" +
+                            "Here you can set the desired log level of the Console and the Log File.\n\n" +
+                            "The right column is for the Console.\n" +
+                            "The left side is for the Log File. (it is log.txt and is off by default.)\n\n" +
+                            "We strongly recommend the console log level be no lower than *WARN* as some of this " +
+                            "information can be important when resolving problems.";
                         Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", LogLevelMenu());
                         return;
                     }
-                case "resetdebug": {
-
-                        string text = "";
+                case CallbackResetDebugChat:
+                    {
+                        string text = "Debug chat is already set to PM.";
                         if (Configs.RunningConfig.Owner != Configs.RunningConfig.AdminChat)
                         {
                             text = "Debug chat has been reset to PM.";
                             Configs.RunningConfig.AdminChat = callback.from.id;
                         }
-                        else { text = "Debug chat is already set to PM."; }
                         Methods.answerCallbackQuery(callback.id, text, true);
                         return;
-
                     }
-                case "changedebugchat":
+                case CallbackChangeDebugChat:
                     {
                         Methods.answerCallbackQuery(callback.id);
-                        string text = "*Debug Chat Location Setting*\n\nHere you can restore the settings for where the bot sends Debug messages. To set a Debug Group, add the bot to a group, and perform /setdebug and the bot will use that group for debug output.\n\n`Reset Debug Chat to Private`\nAs the buttons states, this will reset the location of debug messages to PM with you.";
+                        string text = 
+                            "*Debug Chat Location Setting*\n\n" +
+                            "Here you can restore the settings for where the bot sends Debug messages. To set a " +
+                            "Debug Group, add the bot to a group, and perform /setdebug and the bot will use that " +
+                            "group for debug output.\n\n" +
+                            
+                            "`Reset Debug Chat to Private`\n" +
+                            "As the buttons states, this will reset the location of debug messages to PM with you.";
                         Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", ChangeDebugChat());
                         return;
                     }
-                case "operationmode":
+                case CallbackOperationMode:
                     {
                         Methods.answerCallbackQuery(callback.id);
-                        string text = "*Operation Mode Settings*\n\n*WebHook*\nClicking this will bring you to the menu to enable, configure and test your webhook.\nPlease Read [this](http://dreadbot.net/wiki/index.php/WebHook_Explained) page to fully understand what the differences are between Webhook and getUpdates.\n\n`getUpdates`\nThis is a Toggle button specifically for Disabling webhook easily. Clicking it while getUpdates is enabled will do nothing.";
+                        string text = 
+                            "*Operation Mode Settings*\n\n" +
+                            "*WebHook*\n" +
+                            "Clicking this will bring you to the menu to enable, configure and test your webhook.\n" +
+                            "Please Read [this](http://dreadbot.net/wiki/index.php/WebHook_Explained) page to fully " +
+                            "understand what the differences are between Webhook and getUpdates.\n\n" +
+                            
+                            "`getUpdates`\n" +
+                            "This is a Toggle button specifically for Disabling webhook easily. Clicking it while " +
+                            "getUpdates is enabled will do nothing.";
                         Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", OperationMenu());
                         return;
                     }
-                case "webhookcfg":
+                case CallbackWebhookConfig:
                     {
                         Methods.answerCallbackQuery(callback.id);
-                        string text = "*WebHook Config*\n\n`Test & Go Live!`\nClicking this will reach out to the DreadBot site to help you test the accessibility of your bot to make sure webhook was setup correctly.\nOnce verified, the bot will then offer you the chance to make the switch.\n\n`Set URL`\nUse this to set the Full URL you want telegram to use; Example http://dreadbot.net/bot/ \n\n`Set Certificate`\nHere you can configure the SSL/TLS Certificate the bot will use to encrypt communication between your bot and Telegram.\n\n`Port Cfg`\nYou must select a port that the bot will use to listen on for the HTTPS traffic that will be sent by Telegram.";
+                        string text = 
+                            "*WebHook Config*\n\n" +
+                            "`Test & Go Live!`\n" +
+                            "Clicking this will reach out to the DreadBot site to help you test the accessibility " +
+                            "of your bot to make sure webhook was setup correctly.\n" +
+                            "Once verified, the bot will then offer you the chance to make the switch.\n\n" +
+                            "`Set URL`\n" +
+                            "Use this to set the Full URL you want telegram to use; " +
+                            "Example http://dreadbot.net/bot/ \n\n" +
+                            "`Set Certificate`\n" +
+                            "Here you can configure the SSL/TLS Certificate the bot will use to encrypt " +
+                            "communication between your bot and Telegram.\n\n" +
+                            "`Port Cfg`\n" +
+                            "You must select a port that the bot will use to listen on for the HTTPS traffic that " +
+                            "will be sent by Telegram.";
                         Methods.editMessageText(callback.from.id, callback.message.message_id, text, "markdown", WebhookMenu());
                         return;
                     }
 
-                case "showtoken":
+                case CallbackShowToken:
                     {
                         if (callback.from.id == Configs.RunningConfig.Owner)
                         {
                             Methods.answerCallbackQuery(callback.id);
-                            Methods.editMessageText(callback.from.id, callback.message.message_id, "`" + Configs.RunningConfig.token + "`", "markdown", BackOnly("tuneables"));
+                            Methods.editMessageText(callback.from.id, callback.message.message_id, "`" + Configs.RunningConfig.token + "`", "markdown", BackOnly(CallbackSensitiveOptions));
                             return;
                         }
                         else {
@@ -133,12 +239,18 @@ namespace DreadBot
                         }
                         return;
                     }
-                case "changetoken":
+                case CallbackChangeToken:
                     {
                         if (callback.from.id == Configs.RunningConfig.Owner)
                         {
                             Methods.answerCallbackQuery(callback.id);
-                            Methods.editMessageText(callback.from.id, callback.message.message_id, "This is a major change to make. Please read [this](http://dreadbot.net/wiki/index.php/Change_Token) page before proceeding.", "markdown", BackOnly("tuneables"));
+                            Methods.editMessageText(
+                                callback.from.id, 
+                                callback.message.message_id, 
+                                "This is a major change to make. Please read " +
+                                "[this](http://dreadbot.net/wiki/index.php/Change_Token) page before proceeding.", 
+                                "markdown", 
+                                BackOnly(CallbackSensitiveOptions));
                             return;
                         }
                         else
@@ -149,12 +261,20 @@ namespace DreadBot
                         }
                         return;
                     }
-                case "changeowner":
+                case CallbackChangeOwner:
                     {
                         if (callback.from.id == Configs.RunningConfig.Owner)
                         {
                             Methods.answerCallbackQuery(callback.id);
-                            Methods.editMessageText(callback.from.id, callback.message.message_id, "If you do this, you will no longer have ANY ACCESS to this bot's options or administrative tools unless given to you by the new owner after the change has been made.\nPlease read [this](http://dreadbot.net/wiki/index.php/Change_Owner) page before proceeding.", "markdown", BackOnly("tuneables"));
+                            Methods.editMessageText(
+                                callback.from.id,
+                                callback.message.message_id, 
+                                "If you do this, you will no longer have ANY ACCESS to this bot's options or " +
+                                "administrative tools unless given to you by the new owner after the change has " +
+                                "been made.\nPlease read [this](http://dreadbot.net/wiki/index.php/Change_Owner) " +
+                                "page before proceeding.", 
+                                "markdown", 
+                                BackOnly(CallbackSensitiveOptions));
                             return;
                         }
                         else
@@ -165,12 +285,12 @@ namespace DreadBot
                         }
                         return;
                     }
-                case "gulhelp":
+                case CallbackGetUpdatesLimit:
                     {
                         Methods.answerCallbackQuery(callback.id, "Changes the Get Updates limit", true);
                         return;
                     }
-                case "gula1": {
+                case CallbackGetUpdatesPlusSmall: {
                         if (callback.from.id == Configs.RunningConfig.Owner)
                         {
                             if (Configs.RunningConfig.GULimit > 100)
@@ -198,7 +318,7 @@ namespace DreadBot
                         }
                         return;
                     }
-                case "gula10":
+                case CallbackGetUpdatesPlusLarge:
                     {
                         if (callback.from.id == Configs.RunningConfig.Owner)
                         {
@@ -232,7 +352,7 @@ namespace DreadBot
                         }
                         return;
                     }
-                case "gulm10":
+                case CallbackGetUpdatesMinusLarge:
                     {
                         if (callback.from.id == Configs.RunningConfig.Owner)
                         {
@@ -266,7 +386,7 @@ namespace DreadBot
                         }
                         return;
                     }
-                case "gulm1":
+                case CallbackGetUpdatesMinusSmall:
                     {
                         if (callback.from.id == Configs.RunningConfig.Owner)
                         {
@@ -308,34 +428,34 @@ namespace DreadBot
         {
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
-            keyboard.addCallbackButton("🎛 DreadBot Management", "dreadbot botadm", 0);
-            keyboard.addCallbackButton("🗄 DataBase Management", "dreadbot dbadm", 1);
-            keyboard.addCallbackButton("⚡️ Plugin Manager", "dreadbot plugadm", 2);
+            keyboard.addCallbackButton("🎛 DreadBot Management", $"dreadbot {CallbackBotManagement}", 0);
+            keyboard.addCallbackButton("🗄 DataBase Management", $"dreadbot {CallbackDatabaseManagement}", 1);
+            keyboard.addCallbackButton("⚡️ Plugin Manager", $"dreadbot {CallbackPluginManagement}", 2);
             return keyboard;
         }
 
-        internal static InlineKeyboardMarkup ManagementMenu()
+        private static InlineKeyboardMarkup ManagementMenu()
         {
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
-            keyboard.addCallbackButton("🔥 Sensitive Options", "dreadbot tuneables", 0);
-            keyboard.addCallbackButton("👮‍♂️ Add/Remove Bot Admins", "dreadbot botadmins", 1);
-            keyboard.addCallbackButton("🗒 Debug Chat Settings", "dreadbot debugchatcfg", 2);
+            keyboard.addCallbackButton("🔥 Sensitive Options", $"dreadbot {CallbackSensitiveOptions}", 0);
+            keyboard.addCallbackButton("👮‍♂️ Add/Remove Bot Admins", $"dreadbot {CallbackBotAdmins}", 1);
+            keyboard.addCallbackButton("🗒 Debug Chat Settings", $"dreadbot {CallbackDebugChat}", 2);
             keyboard.addCallbackButton("🔉 System Sounds", "dreadbot sounds", 3);
             keyboard.addCallbackButton("🔙", "dreadbot adm", 4);
             return keyboard;
         }
 
-        internal static InlineKeyboardMarkup ChangeDebugChat()
+        private static InlineKeyboardMarkup ChangeDebugChat()
         {
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
-            keyboard.addCallbackButton("Reset Debug Chat to Private", "dreadbot resetdebug", 0);
-            keyboard.addCallbackButton("🔙", "dreadbot debugchatcfg", 1);
+            keyboard.addCallbackButton("Reset Debug Chat to Private", $"dreadbot {CallbackResetDebugChat}", 0);
+            keyboard.addCallbackButton("🔙", $"dreadbot {CallbackDebugChat}", 1);
             return keyboard;
         }
 
-        internal static InlineKeyboardMarkup LogLevelMenu()
+        private static InlineKeyboardMarkup LogLevelMenu()
         {
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
@@ -360,18 +480,18 @@ namespace DreadBot
             keyboard.addCallbackButton("File LogLevel - Off " + GetLogLevel(LogLevel.Off, false), "dreadbot fll 0", 6);
             keyboard.addCallbackButton("Console LogLevel - Off " + GetLogLevel(LogLevel.Off), "dreadbot cll 0", 6);
 
-            keyboard.addCallbackButton("🔙", "dreadbot debugchatcfg", 7);
+            keyboard.addCallbackButton("🔙", $"dreadbot {CallbackDebugChat}", 7);
 
             return keyboard;
         }
 
-        internal static InlineKeyboardMarkup DebugChatCfg()
+        private static InlineKeyboardMarkup DebugChatCfg()
         {
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
-            keyboard.addCallbackButton("🧾 Change Debug Chat", "dreadbot changedebugchat", 0);
-            keyboard.addCallbackButton("🔕 Set Debug Chat Log Level", "dreadbot debugchatlevel", 1);
-            keyboard.addCallbackButton("🔙", "dreadbot botadm", 2);
+            keyboard.addCallbackButton("🧾 Change Debug Chat", $"dreadbot {CallbackChangeDebugChat}", 0);
+            keyboard.addCallbackButton("🔕 Set Debug Chat Log Level", $"dreadbot {CallbackLogLevel}", 1);
+            keyboard.addCallbackButton("🔙", $"dreadbot {CallbackBotManagement}", 2);
             return keyboard;
         }
         internal static InlineKeyboardMarkup PluginMgr()
@@ -386,14 +506,12 @@ namespace DreadBot
         {
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
-            string gumode = "";
-            string whmode = "";
-            if (Configs.RunningConfig.GetupdatesMode) { gumode = " ⬅️"; }
-            else { whmode = " ⬅️"; }
+            string getUpdatesSuffix = Configs.RunningConfig.GetupdatesMode ? " ⬅️" : "";
+            string webHooksSuffix = Configs.RunningConfig.GetupdatesMode ? "" : " ⬅️";
 
-            keyboard.addCallbackButton("GetUpdates" + gumode, "dreadbot disablewebhook", 0);
-            keyboard.addCallbackButton("WebHook" + whmode, "dreadbot webhookcfg", 1);
-            keyboard.addCallbackButton("🔙", "dreadbot tuneables", 2);
+            keyboard.addCallbackButton("GetUpdates" + getUpdatesSuffix, $"dreadbot {CallbackWebhookDisable}", 0);
+            keyboard.addCallbackButton("WebHook" + webHooksSuffix, $"dreadbot {CallbackWebhookConfig}", 1);
+            keyboard.addCallbackButton("🔙", $"dreadbot {CallbackSensitiveOptions}", 2);
             return keyboard;
         }
 
@@ -402,51 +520,49 @@ namespace DreadBot
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
 
-            keyboard.addCallbackButton("Test & Go Live!", "dreadbot disablewebhook", 0);
-            keyboard.addCallbackButton("Set URL", "dreadbot webhookcfg", 1);
-            keyboard.addCallbackButton("Set Certificate", "dreadbot webhookcfg", 2);
+            keyboard.addCallbackButton("Test & Go Live!", $"dreadbot {CallbackWebhookDisable}", 0);
+            keyboard.addCallbackButton("Set URL", $"dreadbot {CallbackWebhookConfig}", 1);
+            keyboard.addCallbackButton("Set Certificate", $"dreadbot {CallbackWebhookConfig}", 2);
 
-            keyboard.addCallbackButton("Port Cfg", "dreadbot webhookcfg", 3);
-            keyboard.addCallbackButton("443", "dreadbot webhookcfg", 3);
-            keyboard.addCallbackButton("+", "dreadbot webhookcfg", 3);
+            keyboard.addCallbackButton("Port Cfg", $"dreadbot {CallbackWebhookConfig}", 3);
+            keyboard.addCallbackButton("443", $"dreadbot {CallbackWebhookConfig}", 3);
+            keyboard.addCallbackButton("+", $"dreadbot {CallbackWebhookConfig}", 3);
 
-            keyboard.addCallbackButton("🔙", "dreadbot operationmode", 4);
+            keyboard.addCallbackButton("🔙", $"dreadbot {CallbackOperationMode}", 4);
             return keyboard;
         }
-
-
-
-        internal static InlineKeyboardMarkup TuneablesMenu()
+        
+        private static InlineKeyboardMarkup SensitiveOptionsMenu()
         {
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
-            keyboard.addCallbackButton("🔑 Show Access Token", "dreadbot showtoken", 0);
-            keyboard.addCallbackButton("🔑 Change Access Token", "dreadbot changetoken", 1);
-            keyboard.addCallbackButton("👮‍️ Change Owner", "dreadbot changeowner", 2);
+            keyboard.addCallbackButton("🔑 Show Access Token", $"dreadbot {CallbackShowToken}", 0);
+            keyboard.addCallbackButton("🔑 Change Access Token", $"dreadbot {CallbackChangeToken}", 1);
+            keyboard.addCallbackButton("👮‍️ Change Owner", $"dreadbot {CallbackChangeOwner}", 2);
 
-            keyboard.addCallbackButton("+1", "dreadbot gula1", 3);
-            keyboard.addCallbackButton("+10", "dreadbot gula10", 3);
-            keyboard.addCallbackButton(Configs.RunningConfig.GULimit.ToString(), "dreadbot gulhelp", 3);
-            keyboard.addCallbackButton("-10", "dreadbot gulm10", 3);
-            keyboard.addCallbackButton("-1", "dreadbot gulm1", 3);
+            keyboard.addCallbackButton("+1", $"dreadbot {CallbackGetUpdatesPlusSmall}", 3);
+            keyboard.addCallbackButton("+10", $"dreadbot {CallbackGetUpdatesPlusLarge}", 3);
+            keyboard.addCallbackButton(Configs.RunningConfig.GULimit.ToString(), $"dreadbot {CallbackGetUpdatesLimit}", 3);
+            keyboard.addCallbackButton("-10", $"dreadbot {CallbackGetUpdatesMinusLarge}", 3);
+            keyboard.addCallbackButton("-1", $"dreadbot {CallbackGetUpdatesMinusSmall}", 3);
 
-            keyboard.addCallbackButton("⚙️ Bot Operation Mode", "dreadbot operationmode", 4);
-            keyboard.addCallbackButton("🔙", "dreadbot botadm", 5);
+            keyboard.addCallbackButton("⚙️ Bot Operation Mode", $"dreadbot {CallbackOperationMode}", 4);
+            keyboard.addCallbackButton("🔙", $"dreadbot {CallbackBotManagement}", 5);
             return keyboard;
 
         }
 
-        internal static InlineKeyboardMarkup BackOnly(string CallBack)
+        private static InlineKeyboardMarkup BackOnly(string callBack)
         {
             InlineKeyboardMarkup keyboard = new InlineKeyboardMarkup();
             
-            keyboard.addCallbackButton("🔙", "dreadbot " + CallBack, 0);
+            keyboard.addCallbackButton("🔙", "dreadbot " + callBack, 0);
             return keyboard;
         }
 
         #endregion
 
-        internal static string GetLogLevel(LogLevel level, bool console = true)
+        private static string GetLogLevel(LogLevel level, bool console = true)
         {
             return "";
         }

--- a/source/Utilities.cs
+++ b/source/Utilities.cs
@@ -174,8 +174,7 @@ namespace DreadBot
                             return true;
                         }
                         Logger.LogAdmin("Admin Menu Called: " + msg.from.id);
-                        Result<Message> res = Methods.sendMessage(msg.from.id, "*DreadBot Administration Menu*\n\n`DreadBot Managment`\nUsed to fine tune the bot, plus other senstive, and powerful options.\n\n`DataBase Management`\nConfigure Specific Database options, and backup as needed.\n\n`Plugin Manager`\nAdd, Remove and Configure plugins to give DreadBot its purpose.", "Markdown", Menus.AdminMenu());
-                        if (!res.ok) { Logger.LogError("Error contacting the admin Chat: " + res.description); }
+                        Menus.PostAdminMenu(msg.from.id);
                         return true;
                     }
                 case "admin":


### PR DESCRIPTION
This is partially related to https://github.com/ZapDragon/DreadBot/issues/1
But only partially. It's a patch for when that is done, along with some general neatness changes to make working with that class a little nicer.
Summary:
- Adding a default menu page, which explains the menu option has not yet been implemented, and directs back to the root menu
- Extracting constants for callback names, for consistency
- Split very long lines to fit on screen, splitting mostly just at newlines
- Pulling admin menu root posting into Menus class, rather than Utilities
- Making methods private when not used outside of Menus class
